### PR TITLE
clinica: Corrigiendo fallo de instalación

### DIFF
--- a/clinica/__openerp__.py
+++ b/clinica/__openerp__.py
@@ -34,9 +34,8 @@
     """,
     'update_xml': [],
     "data" : [
-        
-        'view/res_partner_inherit_view.xml',
         'view/cli_procedencia_paciente_view.xml',
+        'view/res_partner_inherit_view.xml',
         
         ],
     'installable': True,

--- a/clinica/view/cli_procedencia_paciente_view.xml
+++ b/clinica/view/cli_procedencia_paciente_view.xml
@@ -44,6 +44,10 @@
         </field>
     </record>
             
+    <menuitem   name="Clínica" 
+                id="menu_principal_clinica" 
+                sequence="10" 
+                />
     
     
     <menuitem   name="Procedencia de Pacientes" 

--- a/clinica/view/res_partner_inherit_view.xml
+++ b/clinica/view/res_partner_inherit_view.xml
@@ -45,10 +45,6 @@
     </record>
             
     
-    <menuitem   name="Clínica" 
-                id="menu_principal_clinica" 
-                sequence="10" 
-                />
     <menuitem   name="Registro de Pacientes" 
                 id="registro_pacientes_id" 
                 parent="menu_principal_clinica"


### PR DESCRIPTION
[FIX] En el __openerp__.py se invitieron la declaración de los archivos
xml para que el record de action exita cuando sea llamado.
adicionalmente se movio en menuiten principal (menu_principal_clinica) para el archivo
cli_procedencia_paciente_view.xml para que exitiera el parent, ya que originalmente estaba en
res_partner_inherit_view y cuando era llamado no exitia.